### PR TITLE
Cutoff method names in diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,4 @@ target/
 
 # pyenv
 .python-version
-
+venv

--- a/pytest_changed.py
+++ b/pytest_changed.py
@@ -6,7 +6,7 @@ import re
 import _pytest
 from git import Repo
 
-MATCH_PATTERN = r".*(?:def|class)\s([a-zA-Z_0-9]*).*\:"
+MATCH_PATTERN = r".*(?:def|class)\s([a-zA-Z_0-9]*).*"
 
 
 def pytest_addoption(parser):

--- a/tests/test_changed.py
+++ b/tests/test_changed.py
@@ -149,6 +149,32 @@ GIT_DIFF_ADDED_AND_RENAMED_CODE = \
     b'+     def test_class_one_test_two(self):\n' \
     b'+         assert 1 + 1 == 2\n'
 
+GIT_DIFF_CHANGE_IN_FUNCTION_CUT_OFF_METHOD_PARAMS = \
+    b'diff --git a/dummy_test.py b/dummy_test.py\n' \
+    b'index 6575e440acc807efabcbc156b8683c6344b6fda4..' \
+    b'11314b99949c7e987f050255fa4d0c6497c529bc 100644\n' \
+    b'--- a/dummy_test.py\n' \
+    b'+++ b/dummy_test.py\n' \
+    b'@@ -4,6 +4,7 @@ import pytest\n' \
+    b' class TestClassOne:\n' \
+    b'\n' \
+    b'     def test_class_one_test_one\n' \
+    b'+\n' \
+    b'         assert 1 + 1 == 2\n' \
+    b'\n' \
+    b'     def test_class_one_test_two(self):\n' \
+    b'         assert 1 + 1 == 2\n' \
+    b'\n' \
+    b'\n' \
+    b' class TestClassTwo:\n' \
+    b'\n' \
+    b'     def test_class_two_test_one(\n' \
+    b'+\n' \
+    b'         assert 1 + 1 == 2\n' \
+    b'\n' \
+    b'     def test_class_two_test_two(self):\n' \
+    b'         assert 1 + 1 == 2\n'
+
 
 def test_shows_changed_tests(testdir):
     with patch("pytest_changed.Repo"):
@@ -222,7 +248,11 @@ def test_output_removed_code(
 
 @pytest.mark.parametrize(
     "git_diff",
-    [GIT_DIFF_CHANGE_IN_FUNCTION, GIT_DIFF_CODE_REMOVED_IN_FUNCTION]
+    [
+        GIT_DIFF_CHANGE_IN_FUNCTION,
+        GIT_DIFF_CODE_REMOVED_IN_FUNCTION,
+        GIT_DIFF_CHANGE_IN_FUNCTION_CUT_OFF_METHOD_PARAMS
+     ]
 )
 @patch("pytest_changed.get_changed_files")
 def test_output_removed_code_in_function(
@@ -253,10 +283,11 @@ def test_output_removed_code_in_function(
 
     with patch("pytest_changed.Repo"):
         result = testdir.runpytest("--changed")
+        pytest_output = result.stdout.str()
         assert "Changed test files... 1:\n" \
                "+ %s/dummy_test.py:\n" \
                "  ['test_class_one_test_one', 'test_class_two_test_one']" \
-               % str(testdir.tmpdir) in result.stdout.str()
+               % str(testdir.tmpdir) in pytest_output
 
 
 @patch("pytest_changed.get_changed_files")

--- a/tests/test_changed.py
+++ b/tests/test_changed.py
@@ -26,10 +26,10 @@ GIT_DIFF_CHANGE_IN_FUNCTION = \
     b' class TestClassTwo:\n' \
     b'\n' \
     b'     def test_class_two_test_one(self):\n' \
+    b'+\n' \
     b'         assert 1 + 1 == 2\n' \
     b'\n' \
     b'     def test_class_two_test_two(self):\n' \
-    b'+\n' \
     b'         assert 1 + 1 == 2\n'
 
 GIT_DIFF_CHANGE_IN_CLASS = \
@@ -236,7 +236,7 @@ def test_output_removed_code_in_function(
     their names will also be detected.
     """
     diff = MagicMock()
-    diff.diff = GIT_DIFF_CODE_REMOVED_IN_FUNCTION
+    diff.diff = git_diff
     diff.a_path = "dummy_test.py"
 
     modified_mock = MagicMock()


### PR DESCRIPTION
If a method declaration is rather long it is cut off by the diff. I propose we battle this by changing the regex used to detect method declaration.

This PR fixed issues with cutoff method declarations, provides a covering test and adds some misc/non-functional changes.